### PR TITLE
feat!: the players argument in effect:Start is now optional

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -3,7 +3,7 @@ local exports = require(script.exports)
 table.freeze(exports)
 
 export type ServerProxy<K, V, T...> = {
-	Start: (ServerProxy<K, V, T...>, { Player }) -> ServerProxy<K, V, T...>,
+	Start: (ServerProxy<K, V, T...>, ({ Player })?) -> ServerProxy<K, V, T...>,
 	GetPlayers: (ServerProxy<K, V, T...>) -> { Player },
 	Destroy: (ServerProxy<K, V, T...>) -> ServerProxy<K, V, T...>,
 } & K & Effect<K, V, T...>

--- a/src/init.luau
+++ b/src/init.luau
@@ -3,7 +3,7 @@ local exports = require(script.exports)
 table.freeze(exports)
 
 export type ServerProxy<K, V, T...> = {
-	Start: (ServerProxy<K, V, T...>, ({ Player })?) -> ServerProxy<K, V, T...>,
+	Start: (ServerProxy<K, V, T...>, { Player }?) -> ServerProxy<K, V, T...>,
 	GetPlayers: (ServerProxy<K, V, T...>) -> { Player },
 	Destroy: (ServerProxy<K, V, T...>) -> ServerProxy<K, V, T...>,
 } & K & Effect<K, V, T...>

--- a/src/serverProxy.luau
+++ b/src/serverProxy.luau
@@ -37,7 +37,10 @@ return function(ctorName, ...)
 		Start = function(...)
 			local providedPlayers = omitSelf(...)
 
-			logger.assert(t.optional(t.array(t.instance("Player")))(providedPlayers), "Provide a valid array of players to :Start().")
+			logger.assert(
+				t.optional(t.array(t.instance("Player")))(providedPlayers),
+				"Provide a valid array of players to :Start()."
+			)
 			logger.assert(not initialized, "Cannot :Start() effect twice.")
 
 			players = providedPlayers or Players:GetPlayers()

--- a/src/serverProxy.luau
+++ b/src/serverProxy.luau
@@ -10,6 +10,8 @@ local nextId = createIdGenerator()
 
 local t = require(script.Parent.modules.t)
 
+local Players = game:GetService("Players")
+
 return function(ctorName, ...)
 	local params = { ... }
 	params[0] = "__REFX_HOLD"
@@ -33,11 +35,12 @@ return function(ctorName, ...)
 
 	local reservedFunctions = {
 		Start = function(...)
-			local plrs = omitSelf(...)
-			logger.assert(t.array(t.instance("Player"))(plrs), "Provide a valid array of players to :Start().")
+			local providedPlayers = omitSelf(...)
+
+			logger.assert(t.optional(t.array(t.instance("Player")))(providedPlayers), "Provide a valid array of players to :Start().")
 			logger.assert(not initialized, "Cannot :Start() effect twice.")
 
-			players = plrs
+			players = providedPlayers or Players:GetPlayers()
 			initialized = true
 
 			remotes.__refx_create:firePlayers(players, ctorName, id, params)

--- a/src/tests/serverProxy.spec.luau
+++ b/src/tests/serverProxy.spec.luau
@@ -14,10 +14,6 @@ return function()
 			expect(function()
 				proxy:Start(1 :: any)
 			end).to.throw()
-
-			expect(function()
-				proxy:Start(nil :: any)
-			end).to.throw()
 		end)
 	end)
 


### PR DESCRIPTION
To simplify working with effects, I made the Players argument optional and added the default argument as all players, because in most tasks you need to run effects for all players.